### PR TITLE
Update ish_proper_unload.script

### DIFF
--- a/UnloadAll/gamedata/scripts/ish_proper_unload.script
+++ b/UnloadAll/gamedata/scripts/ish_proper_unload.script
@@ -54,7 +54,7 @@ function unload_all_the_things(self)
 end
 
 function unload_weapon(_, obj)
-    for _, strategy in pairs(unload_strategies) do
+    for _, strategy in ipairs(unload_strategies) do
         local handled = strategy(obj)
         if handled then
             return
@@ -63,7 +63,7 @@ function unload_weapon(_, obj)
 end
 
 function validate(obj)
-    if not IsWeapon(obj) and (not IsItem("fake_ammo_wpn", obj:section())) then
+    if (not IsWeapon(obj)) or  IsItem("fake_ammo_wpn", obj:section())) then
         return true
     end
 end


### PR DESCRIPTION
ipairs should be used with arrays, guarantees order and is faster. was probably intended 

not has a higher priority than and  original logic only and always evaluate to true if IsWeapon was false, making the fake_ammo check redundant. and letting melee weapons thru to the other functions. as a result that logic kept trying to unload knives spamming the log. This logic works as intended and is probably the easiest to read.